### PR TITLE
Add org-wide README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,6 @@
-# .github
+# Neo project GitHub
+
+This repository contains an organization-wide profile README as well as a set
+of policies describing how organization works and what it expects from its
+contributors. Generic workflows and templates reused by multiple other
+repositories in the organization are also stored here.

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,44 @@
+Neo is an open-source community-driven blockchain platform. The main products
+you can find here are Neo blockchain node, developer tools and documentation.
+PRs and issues are welcome in every repository.
+
+# Node
+
+You can get the node from the [neo](https://github.com/neo-project/neo) repository.
+Take a look at [neo-modules](https://github.com/neo-project/neo-modules) as well,
+because it contains many useful plugins for it (like RPC server that is not a
+part of the default node).
+
+# Developer tools
+
+To develop smart contracts for Neo in C# you need
+[neo-devpack-dotnet](https://github.com/neo-project/neo-devpack-dotnet).
+[neo-debugger](https://github.com/neo-project/neo-debugger) can be used to
+debug contracts written in any language. See also:
+* [neo-blockchain-toolkit](https://github.com/neo-project/neo-blockchain-toolkit)
+* [neo-visual-tracker](https://github.com/neo-project/neo-visual-tracker)
+* [neo-express](https://github.com/neo-project/neo-express)
+
+# Documentation and websites
+
+[proposals](https://github.com/neo-project/proposals) is where Neo standards
+(aka Neo Enhancement Proposals or NEPs) are maintained. These are the ultimate
+reference for protocol operation and inter-component interfaces. They're however
+a bit more formal and we recommend starting from documentation below for
+beginners.
+
+[docs](https://github.com/neo-project/docs) is what drives
+[docs.neo.org](https://docs.neo.org), the reference source of documentation on
+concepts and system APIs. [neo-dev-portal](https://github.com/neo-project/neo-dev-portal)
+is the repository behind [developers.neo.org](https://developers.neo.org/) which
+covers more diverse spectrum of tools and provides more complete integration
+examples.
+
+[neo.org](https://github.com/neo-project/neo.org) is about [neo.org](https://neo.org)
+contents, if you've spotted a typo there you're welcome to submit issue/PR.
+
+# Special ones
+
+[non-native-contracts](https://github.com/neo-project/non-native-contracts/)
+contains some well-known contracts (like NNS) deployed to both testnet and
+mainnet and useful for general audience.


### PR DESCRIPTION
Org-wide README will be displayed on https://github.com/neo-project/ and the purpose of it is to be a bit more useful than just a repo list.

@shargon, @Jim8y, @cschuchardt88, please help me with developer tools, I'm not aware of their current status and relations. Maybe some or them are obsolete, maybe I'm wrong in some descriptions.